### PR TITLE
Highlighting and excerpting

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -526,6 +526,10 @@ class DictSearchResults(SearchResults):
                         for r in hits]
 
 
+class _ListResult(list):
+    """Wrapper for a list that allows us to attach other attributes"""
+
+
 class ListSearchResults(SearchResults):
     def set_objects(self, hits):
         if self.fields:
@@ -533,7 +537,8 @@ class ListSearchResults(SearchResults):
             objs = [getter(r['fields']) for r in hits]
         else:
             objs = [r['_source'].values() for r in hits]
-        self.objects = objs
+        self.objects = [_decorate_with_highlights(_ListResult(o), h)
+                        for o, h in izip(objs, hits)]
 
 
 class ObjectSearchResults(SearchResults):


### PR DESCRIPTION
Will: r?

It turns out passing the search result into excerpt() is insufficient, because in ES, we need the original 'highlight' hash key from the raw results, not the field content from the found document to throw at some BuildExcerpt analogue. There's no wonderful way of matching up a result object with a raw results entry after the fact, short of scanning through for equal document IDs (which may not be in the result object in the case of dict-style or list-style results). So instead, I simply(?) annotate the result objects with their highlights hash when we first make them. To allow this, I have to wrap the lists and dicts in a dummy new-style class, but instance() and everything else but type() and **class** are maintained, so I don't think it'll break anything.
