### PR TITLE
DEFAULT_INDEXES and DEFAULT_DOCTYPES are plural

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -13,8 +13,8 @@ log = logging.getLogger('elasticutils')
 
 DEFAULT_HOSTS = ['localhost:9200']
 DEFAULT_TIMEOUT = 5
-DEFAULT_DOCTYPES = None
-DEFAULT_INDEXES = 'default'
+DEFAULT_DOCTYPES = ['document']
+DEFAULT_INDEXES = ['default']
 DEFAULT_DUMP_CURL = None
 
 
@@ -621,7 +621,6 @@ class S(object):
         for action, value in reversed(self.steps):
             if action == 'indexes':
                 return value
-
         return default_indexes
 
     def get_doctypes(self, default_doctypes=DEFAULT_DOCTYPES):

--- a/elasticutils/tests/test_es.py
+++ b/elasticutils/tests/test_es.py
@@ -13,7 +13,7 @@ class ESTest(TestCase):
         # dump_curl defaults to False, but if dump_curl is Falsey,
         # then pyes.es.ES sets its dump_curl attribute to None.
         eq_(es.dump_curl, None)
-        eq_(es.default_indexes, [DEFAULT_INDEXES])
+        eq_(es.default_indexes, DEFAULT_INDEXES)
 
     def test_get_es_overriding_defaults(self):
         """Test that overriding defaults works."""

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -35,7 +35,7 @@ class HasDataTestCase(ElasticTestCase):
         es.delete_index(cls.index_name)
 
     def get_s(self):
-        return S().indexes(self.index_name)
+        return S().indexes(self.index_name).doctypes(FakeModel._meta.db_table)
 
 
 class QueryTest(HasDataTestCase):
@@ -329,12 +329,16 @@ class QueryTest(HasDataTestCase):
 class ResultsTests(HasDataTestCase):
     def test_default_results_are_dicts(self):
         """With untyped S, return dicts."""
-        searcher = list(S().indexes(self.index_name).query(foo='bar'))
+        searcher = list(S().indexes(self.index_name)
+                           .doctypes(FakeModel._meta.db_table)
+                           .query(foo='bar'))
         assert isinstance(searcher[0], dict)
 
     def test_typed_s_returns_type(self):
         """With typed S, return objects of type."""
-        searcher = list(S(FakeModel).indexes(self.index_name).query(foo='bar'))
+        searcher = list(S(FakeModel).indexes(self.index_name)
+                                    .doctypes(FakeModel._meta.db_table)
+                                    .query(foo='bar'))
         assert isinstance(searcher[0], FakeModel)
 
     def test_values_dict_results(self):


### PR DESCRIPTION
These two defaults were wrong--they're both plural and should be a list
of strings. Other values are wrong.

This fixes that and also fixes a bunch of tests that broke because of it.

r?
