### PR TITLE
Fix boosted text_phrase queries

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -205,10 +205,8 @@ def _boosted_value(name, action, key, value, boost):
         # Note: Most queries use 'value' for the key name except Text
         # queries which use 'query'. So we have to do some switcheroo
         # for that.
-        return {
-            name: {
-                'boost': boost,
-                'query' if action == 'text' else 'value': value}}
+        value_key = 'query' if action in ['text', 'text_phrase'] else 'value'
+        return {name: {'boost': boost, value_key: value}}
     return {name: value}
 
 

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -174,6 +174,15 @@ class QueryTest(ElasticTestCase):
         eq_(f2.filters, {'not': {'filter': {'term': {'fielda': 'boat'}}}})
 
     def test_boost(self):
+        """Boosted queries shouldn't raise a SearchPhaseExecutionException."""
+        # Note: There isn't an assertion here--we just want to make
+        # sure that it runs without throwing an exception.
+        q1 = (self.get_s()
+                  .boost(foo=4.0)
+                  .query(foo='car', foo__text='car', foo__text_phrase='car'))
+        list(q1)
+
+    def test_boost_overrides(self):
         def _get_queries(search):
             # The stuff we want is buried in the search and it's in
             # the 'must' list where each item in the list is a dict


### PR DESCRIPTION
text_phrase queries are really just text queries, so they require the
same value_key name. This fixes that and also writes a test for boosts
that runs through ES so we can verify it doesn't kick up a
SeachPhaseWhateverThingy.

r?
