### PR TITLE
Add run_tests.py to setup Django for testing.

### DIFF
--- a/docs/dev_testing.rst
+++ b/docs/dev_testing.rst
@@ -5,23 +5,21 @@ Running and writing tests
 Running the tests
 =================
 
-If you don't have Django installed, you can run the tests with::
+You can run the tests with::
 
-    nosetests
+    ./run_tests.py
 
-It will skip the Django tests.
-
-If you do have Django installed, then you need to specify
-``DJANGO_SETTINGS_MODULE``. Run the tests like this::
-
-    DJANGO_SETTINGS_MODULE=test_settings nosetests
+If you have Django installed, this will run the Django-specific tests. If you
+don't, then the test runner will skip the Django-specific tests.
 
 
 .. Note::
 
    If you need to adjust the settings, copy ``test_settings.py`` to a
-   new file (like ``test_settings_local.py``), edit the file, and pass
-   that in as the value for ``DJANGO_SETTINGS_MODULE``.
+   new file (like ``test_settings_local.py``), edit the file, and specify that
+   as the value for the environment variable ``DJANGO_SETTINGS_MODULE``.
+
+       DJANGO_SETTINGS_MODULE=test_settings_local ./run_tests.py
 
    This is helpful if you need to change the value of ``ES_HOSTS`` to
    match the ip address or port that elasticsearch is listening on.

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+import nose
+
+
+# Set up the environment for our test project.
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
+try:
+    # import to check for the existence of Django
+    import django
+    os.environ.update({'DJANGO_SETTINGS_MODULE': 'test_settings'})
+    sys.path.insert(0, ROOT)
+
+    # This can't be imported until after we've fiddled with the
+    # environment.
+    from django.test.utils import setup_test_environment
+    setup_test_environment()
+except ImportError:
+    # If django is not found, the Django tests will be skipped, so this is ok.
+    pass
+
+# Run nose.
+#
+# nose.run() returns True if tests passed and False otherwise which is
+# the inverse of what we want the process to return, so we invert it.
+sys.exit(not nose.run())


### PR DESCRIPTION
This will set up the Django environment so the Django-specific tests can
run. If Django is not present, the setup will be skipped and the tests
will be run normally. The testsuite will skip any Django-specific tests
in this case. This simplifies running the full test suite.

Note that without Django, an exception is raised on one test, but this happened before too.
