### PR TITLE
[Issue 97] Add logic to filter by None.

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -132,9 +132,12 @@ def _process_filters(filters):
             key, val = f
             key, field_action = _split(key)
             if key == 'or_':
-                rv.append({'or':_process_filters(val.items())})
+                rv.append({'or': _process_filters(val.items())})
             elif field_action is None:
-                rv.append({'term': {key: val}})
+                if val is None:
+                    rv.append({'missing': {'field': key, "null_value": True}})
+                else:
+                    rv.append({'term': {key: val}})
             elif field_action in ('startswith', 'prefix'):
                 rv.append({'prefix': {key: val}})
             elif field_action == 'in':


### PR DESCRIPTION
ElasticSearch doesn't really allow filtering by None, instead you have to make a filter that asks "is this field missing?". Weird. This turns `key=None` filters into `"missing": {"field": "key"}` queries.

This is a fix for #97. This commit cherry picks cleanly onto the commit tagged `0.6`.
