### PR TITLE
Fix tests without Django being installed

### DIFF
--- a/elasticutils/contrib/django/__init__.py
+++ b/elasticutils/contrib/django/__init__.py
@@ -11,7 +11,8 @@ try:
     from django.shortcuts import render
     from django.utils.decorators import decorator_from_middleware_with_args
 except ImportError:
-    pass
+    def decorator_from_middleware_with_args(func):
+        return func
 
 
 log = logging.getLogger('elasticutils')


### PR DESCRIPTION
Properly skip all tests when Django isn't available.
