### PR TITLE
Add basic travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 install:
     - virtualenv .
     - ./bin/pip install -r requirements-dev.txt
-    - [ $DJANGO = "true" ] && bin/pip install -r requirements-django.txt || echo
+    - "[ $DJANGO = true ] && bin/pip install -r requirements-django.txt || echo"
 
 script:
     - ./bin/python run_tests.py


### PR DESCRIPTION
This addresses #107.

It doesn't yet test against different versions of elasticsearch, but it's easy to extend to that later. The non-django tests fail until #112 is merged.
