### PR TITLE
Add support for match queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -208,6 +208,17 @@ Version 0.7: in development
   Allows you to get **all** the search results possible. This is
   dangerous, so it's been documented with lots of warnings.
 
+* **Added support for ``match`` and ``match_phrase`` queries.**
+
+  Elasticsearch 0.19.9 renamed text query to match query. This adds
+  support for match and match_phrase. 
+
+* **S.query_raw added**
+
+  If ``.query()`` is getting you down, then you can skip it and use
+  the Elasticsearch API to create the query clause of the search
+  by hand.
+
 
 Version 0.6: Released January 17th, 2013
 ========================================

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -458,18 +458,25 @@ field action            elasticsearch query
 (no action specified)   term query
 term                    term query
 text                    text query
-prefix                  prefix query [1]_
+match                   match query [1]_
+prefix                  prefix query [2]_
 gt, gte, lt, lte        range query
 fuzzy                   fuzzy query
 text_phrase             text_phrase query
-query_string            query_string query [2]_
+match_phrase            match_phrase query [1]_
+query_string            query_string query [3]_
 ======================  =======================
 
 
-.. [1] You can also use ``startswith``, but that's deprecated.
+.. [1] Elasticsearch 0.19.9 renamed text queries to match queries. If
+       you're using Elasticsearch 0.19.9 or later, you should use
+       match and match_phrase. If you're using a version prior to
+       0.19.9 use text and text_phrase.
 
-.. [2] When doing ``query_string`` queries, if the query text is malformed
-   it'll raise a `SearchPhaseExecutionException` exception.
+.. [2] You can also use ``startswith``, but that's deprecated.
+
+.. [3] When doing ``query_string`` queries, if the query text is malformed
+       it'll raise a `SearchPhaseExecutionException` exception.
 
 
 .. seealso::
@@ -482,6 +489,9 @@ query_string            query_string query [2]_
 
    http://www.elasticsearch.org/guide/reference/query-dsl/text-query.html
      ElasticSearch docs on text and text_phrase queries
+
+   http://www.elasticsearch.org/guide/reference/query-dsl/match-query.html
+     ElasticSearch docs on match and match_phrase queries
 
    http://www.elasticsearch.org/guide/reference/query-dsl/prefix-query.html
      ElasticSearch docs on prefix queries

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -33,6 +33,9 @@ class QueryTest(ElasticTestCase):
     def test_q_text(self):
         eq_(len(self.get_s().query(foo__text='car')), 2)
 
+    def test_q_match(self):
+        eq_(len(self.get_s().query(foo__match='car')), 2)
+
     def test_q_prefix(self):
         eq_(len(self.get_s().query(foo__prefix='ca')), 2)
         eq_(len(self.get_s().query(foo__startswith='ca')), 2)
@@ -50,6 +53,20 @@ class QueryTest(ElasticTestCase):
         # Doing a text_phrase query for the two words in the wrong order
         # kicks up no results.
         eq_(len(self.get_s().query(foo__text_phrase='car train')), 0)
+
+    def test_q_text_match(self):
+        # Doing a match query for the two words in either order kicks up
+        # two results.
+        eq_(len(self.get_s().query(foo__match='train car')), 2)
+        eq_(len(self.get_s().query(foo__match='car train')), 2)
+
+        # Doing a match_phrase query for the two words in the right
+        # order kicks up one result.
+        eq_(len(self.get_s().query(foo__match_phrase='train car')), 1)
+
+        # Doing a match_phrase query for the two words in the wrong
+        # order kicks up no results.
+        eq_(len(self.get_s().query(foo__match_phrase='car train')), 0)
 
     def test_q_fuzzy(self):
         # Mispelled word gets no results with text query.


### PR DESCRIPTION
Elasticsearch 0.19.9 renamed text queries to match queries. This
adds support for the new name.

r?
