### PR TITLE
Fix .demote() in regards to .query_raw()

### DIFF
--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -105,6 +105,9 @@ class QueryTest(ElasticTestCase):
     def test_query_raw_overrides_everything(self):
         s = self.get_s().query_raw({'match': {'title': 'example'}})
         s = s.query(foo__text='foo')
+        s = s.demote(0.5, title__text='bar')
+        s = s.boost(title=5.0)
+
         eq_(s._build_query(),
             {'query': {'match': {'title': 'example'}}})
 


### PR DESCRIPTION
If the dev has specified .query_raw(), that should cause EU to ignore
_all_ things that modify the query clause of the search including
.query(), .demote() and .boost().

This fixes that, updates the test and updates the docs. While I was doing
that I fleshed out the docs for .boost() and .demote().

r?
