### PR TITLE
[Doc] Fixed: Indexing examples lack the `properties` key when configuring mappings

### DIFF
--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -101,12 +101,16 @@ For example:
 
     es = get_es()
     es.put_mapping('blog-index', 'blog-entry-type', {
-        'id': {'type': 'integer'},
-        'title': {'type': 'string'},
-        'content': {'type': 'string'},
-        'tags': {'type': 'string'},
-        'created': {'type': 'date'}
-        })
+        'blog-entry-type': {
+            'properties': {
+                'id': {'type': 'integer'},
+                'title': {'type': 'string'},
+                'content': {'type': 'string'},
+                'tags': {'type': 'string'},
+                'created': {'type': 'date'}
+            }
+        }
+    })
 
 
 You can also define mappings when you create the index:
@@ -117,11 +121,13 @@ You can also define mappings when you create the index:
     es.create_index('blog-index', settings={
         'mappings': {
             'blog-entry-type': {
-                'id': {'type': 'integer'},
-                'title': {'type': 'string'},
-                'content': {'type': 'string'},
-                'tags': {'type': 'string'},
-                'created': {'type': 'date'}
+                'properties': {
+                    'id': {'type': 'integer'},
+                    'title': {'type': 'string'},
+                    'content': {'type': 'string'},
+                    'tags': {'type': 'string'},
+                    'created': {'type': 'date'}
+                }
             }}})
 
 


### PR DESCRIPTION
The code examples for setting up mappings using both `create_index` and `put_mapping` don't include the `properties` key in the dict provided.

As far as I know from ES [doc](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html) the `properties` key is necessary. I tried without providing it and it results in an empty mapping for the created index.
