### PR TITLE
fixes #1 query_string paging problem(from, size not work) fixed

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -1060,7 +1060,7 @@ class S(PythonMixin):
 
         self.fields, self.as_list, self.as_dict = fields, as_list, as_dict
         if qs.has_key('query'):
-            if qs['query'].has_key('query_string') and self.start and self.stop:
+            if qs['query'].has_key('query_string') and self.start!=None and self.stop!=None:
                 qs['query']['query_string']['from'] = self.start
                 qs['query']['query_string']['size'] = self.stop - self.start
         return qs


### PR DESCRIPTION
Paging (start, stop) not work when we use query_string.
So, I fixed that problem.

example code >

_ES_SEARCHER.start = 0
_ES_SEARCHER.stop = 25
_ES_SEARCHER = _ES_SEARCHER.query(name__query_string ={'default_field':'name',\
  'query':"\""+query+"\"",'analyzer':'krlucene_tokenizer',\
  'phrase_slop':10})

idx = 0
for item in _ES_SEARCHER.query().execute():
    print item['name'],item['genre'],item['site_name'],item['date'],item['cmt_num']
    idx+=1
# before fix : idx=10
# after fix : idx=25
