### PR TITLE
Have bulk_index fail on error instead of ignoring it

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -2030,8 +2030,13 @@ class Indexable(object):
 
         documents = (dict(d, _id=d[id_field]) for d in documents)
 
-        bulk_index(es, documents, index=index,
-                   doc_type=cls.get_mapping_type_name())
+        bulk_index(
+            es,
+            documents,
+            index=index,
+            doc_type=cls.get_mapping_type_name(),
+            raise_on_error=True
+        )
 
     @classmethod
     def unindex(cls, id_, es=None, index=None):


### PR DESCRIPTION
currently if one or more of the operations in the bulk request fails it will be silently ignored.
