### PR TITLE
Make _build_query() accept dicts as sort values

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -621,7 +621,9 @@ class S(PythonMixin):
                     .order_by('-title')
 
 
-        You can also sort by the computed field ``_score``.
+        You can also sort by the computed field ``_score`` or pass a dict as
+        a sort field in order to use more advanced sort options.  Read the
+        Elasticsearch documentation for details.
 
         .. Note::
 
@@ -973,7 +975,7 @@ class S(PythonMixin):
             if action == 'order_by':
                 sort = []
                 for key in value:
-                    if key.startswith('-'):
+                    if isinstance(key, basestring) and key.startswith('-'):
                         sort.append({key[1:]: 'desc'})
                     else:
                         sort.append(key)

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -545,6 +545,10 @@ class QueryTest(ESTestCase):
         res = self.get_s().filter(tag='awesome').order_by('-width')
         eq_([d['id'] for d in res], [5, 3, 1])
 
+    def test_order_by_dict(self):
+        res = self.get_s().filter(tag='awesome').order_by({'width': 'desc'})
+        eq_([d['id'] for d in res], [5, 3, 1])
+
     def test_slice(self):
         s = self.get_s().filter(tag='awesome')
         eq_(s._build_query(),


### PR DESCRIPTION
Hi,

This pull request allows developers to use dicts as sort values in `order_by()`. This is useful to do [nested object filtering](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html#_sorting_within_nested_objects), which I'd like to use that in Firefox Marketplace to fix https://bugzilla.mozilla.org/show_bug.cgi?id=951626
