### PR TITLE
IndexerTasks: Add additional kwargs.

### DIFF
--- a/elasticutils/contrib/django/tasks.py
+++ b/elasticutils/contrib/django/tasks.py
@@ -10,7 +10,7 @@ log = logging.getLogger('elasticutils')
 
 
 @task
-def index_objects(mapping_type, ids, chunk_size=100, index=None, es=None):
+def index_objects(mapping_type, ids, chunk_size=100, es=None, index=None):
     """Index documents of a specified mapping type.
 
     This allows for asynchronous indexing.
@@ -32,10 +32,10 @@ def index_objects(mapping_type, ids, chunk_size=100, index=None, es=None):
        The default chunk_size is 100. The number of documents you can
        bulk index at once depends on the size of the documents.
 
-    :arg index: The name of the index to use. If you don't specify one
-        it'll use `mapping_type.get_index()`.
     :arg es: The `Elasticsearch` to use. If you don't specify an
         `Elasticsearch`, it'll use `mapping_type.get_es()`.
+    :arg index: The name of the index to use. If you don't specify one
+        it'll use `mapping_type.get_index()`.
     """
     if settings.ES_DISABLED:
         return
@@ -59,11 +59,11 @@ def index_objects(mapping_type, ids, chunk_size=100, index=None, es=None):
                         obj, repr(exc)))
 
         if documents:
-            mapping_type.bulk_index(documents, id_field='id', index=index, es=es)
+            mapping_type.bulk_index(documents, id_field='id', es=es, index=index)
 
 
 @task
-def unindex_objects(mapping_type, ids, index=None, es=None):
+def unindex_objects(mapping_type, ids, es=None, index=None):
     """Remove documents of a specified mapping_type from the index.
 
     This allows for asynchronous deleting.
@@ -78,13 +78,13 @@ def unindex_objects(mapping_type, ids, index=None, es=None):
 
     :arg mapping_type: the mapping type for these ids
     :arg ids: the list of ids of things to remove
-    :arg index: The name of the index to use. If you don't specify one
-        it'll use `mapping_type.get_index()`.
     :arg es: The `Elasticsearch` to use. If you don't specify an
         `Elasticsearch`, it'll use `mapping_type.get_es()`.
+    :arg index: The name of the index to use. If you don't specify one
+        it'll use `mapping_type.get_index()`.
     """
     if settings.ES_DISABLED:
         return
 
     for id_ in ids:
-        mapping_type.unindex(id_, index=index, es=es)
+        mapping_type.unindex(id_, es=es, index=index)

--- a/elasticutils/contrib/django/tests/test_tasks.py
+++ b/elasticutils/contrib/django/tests/test_tasks.py
@@ -83,6 +83,6 @@ class TestTasks(ESTestCase):
         eq_(MockMappingType.index_kwarg, None)
         eq_(MockMappingType.es_kwarg, None)
 
-        index_objects(MockMappingType, [1, 2, 3], index='crazy_index', es='crazy_es')
+        index_objects(MockMappingType, [1, 2, 3], es='crazy_es', index='crazy_index')
         eq_(MockMappingType.index_kwarg, 'crazy_index')
         eq_(MockMappingType.es_kwarg, 'crazy_es')


### PR DESCRIPTION
This patch adds two additional keyword arguments to the indexer task `es` and `index`.
