### PR TITLE
Support Minimum Version Checks in Unit Tests

### DIFF
--- a/elasticutils/tests/__init__.py
+++ b/elasticutils/tests/__init__.py
@@ -128,6 +128,20 @@ class ESTestCase(TestCase):
         cls.get_es().indices.refresh(cls.index_name)
         if timesleep:
             time.sleep(timesleep)
+    
+    @classmethod
+    def skip_unless_version(cls, min_version):
+        """Checks that the available elasticsearch server is at least the `min_version` supplied.
+        
+        : arg min_version: tuple of version numbers that represent the minimum version required.
+        """
+        
+        es = cls.get_es()
+        info = es.info()
+        number_string = info['version']['number']
+        number = tuple([int(x) for x in number_string.split('.')])
+        if number < min_version:
+            raise SkipTest("Test requires minimum version of {}".format(min_version))
 
 
 def facet_counts_dict(qs, field):


### PR DESCRIPTION
I ended up not using this for the unit test I submitted with #197, but with ElasticSearch continuing to add new features, I thought future tests would benefit with a way to specify the minimum version of the elastic search server required for the test.
