### PR TITLE
Don't explicitly check if S() type is None

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -31,12 +31,13 @@ QUERY_ACTION_MAP = {
     'text_phrase': 'text_phrase',
     'match': 'match',  # ES 0.19.9 renamed text to match
     'match_phrase': 'match_phrase',
+    'match_phrase_prefix': 'match_phrase_prefix',
     'wildcard': 'wildcard',
     'fuzzy': 'fuzzy'}
 
 
 #: List of text/match actions.
-TEXTMATCH_ACTIONS = ['text', 'text_phrase', 'match', 'match_phrase']
+TEXTMATCH_ACTIONS = ['text', 'text_phrase', 'match', 'match_phrase', 'match_phrase_prefix', ]
 #: List of range actions.
 RANGE_ACTIONS = ['gt', 'gte', 'lt', 'lte']
 


### PR DESCRIPTION
I ran into a problem trying to write a MappingType but still use the behavior of an untyped S() such as searching all indexes. This patch removes special handling for untyped S() and allows other MappingTypes to access the same behavior.

I couldn't find any discussion about this behavior so I'm not sure if this was intentional but I think this change does not break backwards compatibility and allows more flexibility in the future. Please let me know if there is anything else I can do on this.
