### PR TITLE
Ensure results cache is used even if there were no results

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -876,7 +876,7 @@ class S(PythonMixin):
         """
         Return a new S instance with facet args combined with existing
         set.
-        
+
         :arg args: The list of facets to return.
 
         Additional keyword options:
@@ -1447,7 +1447,7 @@ class S(PythonMixin):
         >>> count = s.count()
 
         """
-        if self._results_cache:
+        if self._results_cache is not None:
             return self._results_cache.count
         else:
             return self[:0].raw()['hits']['total']

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -618,6 +618,17 @@ class QueryTest(ESTestCase):
         s.execute()
         assert isinstance(s.count(), int)
 
+    def test_count_empty_results(self):
+        s = self.get_s()
+        s.execute()
+
+        # Simulate a situation where the result cache had 0 objects
+        s._results_cache.objects = []
+        s._results_cache.count = 123
+
+        # Ensure that we are still retrieving the cached result count
+        eq_(s.count(), 123)
+
     def test_len(self):
         assert isinstance(len(self.get_s()), int)
 


### PR DESCRIPTION
On Marketplace, we determined that we were making two requests to Elasticsearch whenever we had a search that returned no results. From some debugging I believe this is because of the way that `self._results_cache` is being evaluated here: https://github.com/mozilla/elasticutils/blob/master/elasticutils/__init__.py#L1450. In cases with no results, the `__len__` method is being being evaluated to 0 which makes this statement falsey (and triggers another request).

This will simply explicitly check if the `self._results_cache` is not `None`.
