### PR TITLE
Do not set facet_filter if there is no filter.

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -1129,7 +1129,7 @@ class S(PythonMixin):
             # None as a shell, so if it's explicitly set to None, then
             # we update it.
             for facet in facets.values():
-                if facet.get('facet_filter', 1) is None:
+                if facet.get('facet_filter', 1) is None and 'filter' in qs:
                     facet['facet_filter'] = qs['filter']
 
         if facets_raw:


### PR DESCRIPTION
I stumbled across this issue when calling .facet(..., filtered=True) on a query that did not have a filter. I'd say that the API should be robust and accept this usecase, especially since you can set up a pipeline that chains various calls on an S() object and ends up calling facet on it.
