### PR TITLE
Move results metadata to es_meta object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -80,6 +80,23 @@ Version 0.9: In development
 
   If you really need a `S._build_query()`, add it to your `S` subclass.
 
+* **Search results metadata is now in the `es_meta` object**
+
+  Previously, you would access search results metadata like this::
+
+      obj._id
+      obj._highlight
+      obj._score
+      etc.
+
+  In order to make those accessible in Django templates, we moved them into
+  an es_meta object. You can now access them like this::
+
+      obj.es_meta.id
+      obj.es_meta.highlight
+      obj.es_meta.score
+      etc.
+
 
 **Changes:**
 

--- a/docs/samples/sample_quickstart.py
+++ b/docs/samples/sample_quickstart.py
@@ -99,7 +99,7 @@ print [item['title']
 # [u'Awesome Bar']
 
 # Do a query and use the highlighter to denote the matching text.
-print [(item['title'], item._highlight['title'])
+print [(item['title'], item.es_meta.highlight['title'])
        for item in basic_s.query(title__text='cookie').highlight('title')]
 # Prints:
 # [

--- a/docs/searching.rst
+++ b/docs/searching.rst
@@ -954,23 +954,24 @@ The same can be done with queries::
   http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-filter-facet.html
     Elasticsearch docs on filter facets
 
+
 .. _scores-and-explanations:
 
 Scores and explanations
 =======================
 
-Seeing the score: _score
-------------------------
+Seeing the score: score
+-----------------------
 
 Wondering what the score for a document was? ElasticUtils puts that in
-the ``_score`` on the search result. For example, let's search an
-index that holds knowledge base articles for ones with the word
-"crash" in them and print out the scores::
+the ``score`` attribute of the ``es_meta`` object of the search result.
+For example, let's search an index that holds knowledge base articles
+for ones with the word "crash" in them and print out the scores::
 
     q = S().query(title__text='crash', content__text='crash')
 
     for result in q:
-        print result._score
+        print result.es_meta.score
 
 This works regardless of what form the search results are in.
 
@@ -983,8 +984,8 @@ that should have shown up higher? Wonder how that score was computed?
 You can set the search to pass the ``explain`` flag to Elasticsearch
 with :py:meth:`elasticutils.S.explain`.
 
-This returns data that will be in every item in the search results
-list as ``_explanation``.
+ElasticUtils puts the explanation in the ``explanation`` attribute
+of the ``es_meta`` object of the search result.
 
 For example, let's do a query on a search corpus of knowledge base
 articles for articles with the word "crash" in them::
@@ -993,7 +994,7 @@ articles for articles with the word "crash" in them::
             .explain())
 
     for result in q:
-        print result._explanation
+        print result.es_meta.explanation
 
 
 This works regardless of what form the search results are in.

--- a/elasticutils/tests/test_query.py
+++ b/elasticutils/tests/test_query.py
@@ -352,10 +352,10 @@ class QueryTest(ESTestCase):
 
     def test_q_demote(self):
         s = self.get_s().query(foo__text='car')
-        scores = [(sr['id'], sr._score) for sr in s.values_dict('id')]
+        scores = [(sr['id'], sr.es_meta.score) for sr in s.values_dict('id')]
 
         s = s.demote(0.5, width__term='5')
-        demoted_scores = [(sr['id'], sr._score) for sr in s.values_dict('id')]
+        demoted_scores = [(sr['id'], sr.es_meta.score) for sr in s.values_dict('id')]
 
         # These are both sorted by scores. We're demoting one result
         # so the top result in each list is different.
@@ -363,10 +363,10 @@ class QueryTest(ESTestCase):
 
         # Now we do the whole thing again with Qs.
         s = self.get_s().query(Q(foo__text='car'))
-        scores = [(sr['id'], sr._score) for sr in s.values_dict('id')]
+        scores = [(sr['id'], sr.es_meta.score) for sr in s.values_dict('id')]
 
         s = s.demote(0.5, Q(width__term='5'))
-        demoted_scores = [(sr['id'], sr._score) for sr in s.values_dict('id')]
+        demoted_scores = [(sr['id'], sr.es_meta.score) for sr in s.values_dict('id')]
 
         # These are both sorted by scores. We're demoting one result
         # so the top result in each list is different.
@@ -679,7 +679,7 @@ class QueryTest(ESTestCase):
         qs = qs.explain(True)
 
         res = list(qs)
-        assert res[0]._explanation
+        assert res[0].es_meta.explanation
 
 
 class FilterTest(ESTestCase):
@@ -1364,7 +1364,7 @@ class HighlightTest(ESTestCase):
         result = list(s)[0]
         # The highlit text from the foo field should be in index 1 of the
         # excerpts.
-        eq_(result._highlight['foo'], [u'train <em>car</em>'])
+        eq_(result.es_meta.highlight['foo'], [u'train <em>car</em>'])
 
         s = (self.get_s().query(foo__text='car')
                          .filter(id=5)
@@ -1373,7 +1373,7 @@ class HighlightTest(ESTestCase):
         result = list(s)[0]
         # The highlit text from the foo field should be in index 1 of the
         # excerpts.
-        eq_(result._highlight['foo'], [u'train <em>car</em>'])
+        eq_(result.es_meta.highlight['foo'], [u'train <em>car</em>'])
 
     def test_highlight_on_list_results(self):
         """Make sure highlighting with list-style results works.
@@ -1389,7 +1389,7 @@ class HighlightTest(ESTestCase):
         result = list(s)[0]
         # The highlit text from the foo field should be in index 1 of the
         # excerpts.
-        eq_(result._highlight['foo'], [u'train <em>car</em>'])
+        eq_(result.es_meta.highlight['foo'], [u'train <em>car</em>'])
 
     def test_highlight_options(self):
         """Make sure highlighting with options works."""
@@ -1401,7 +1401,7 @@ class HighlightTest(ESTestCase):
         result = list(s)[0]
         # The highlit text from the foo field should be in index 1 of the
         # excerpts.
-        eq_(result._highlight['foo'], [u'train <b>car</b>'])
+        eq_(result.es_meta.highlight['foo'], [u'train <b>car</b>'])
 
     def test_highlight_cumulative(self):
         """Make sure highlighting fields are cumulative and none clears them."""
@@ -1409,15 +1409,15 @@ class HighlightTest(ESTestCase):
         s = (self.get_s().query(foo__text='car')
                          .filter(id=5)
                          .highlight())
-        eq_(list(s)[0]._highlight, {})
+        eq_(list(s)[0].es_meta.highlight, {})
 
         # Add a field and that gets highlighted.
         s = s.highlight('foo')
-        eq_(list(s)[0]._highlight['foo'], [u'train <em>car</em>'])
+        eq_(list(s)[0].es_meta.highlight['foo'], [u'train <em>car</em>'])
 
         # Set it back to no fields and no highlight.
         s = s.highlight(None)
-        eq_(list(s)[0]._highlight, {})
+        eq_(list(s)[0].es_meta.highlight, {})
 
 
 class SearchTypeTest(ESTestCase):

--- a/elasticutils/tests/test_results.py
+++ b/elasticutils/tests/test_results.py
@@ -106,31 +106,34 @@ class TestResultsWithData(ESTestCase):
         """Test default results form has metadata."""
         searcher = list(self.get_s().query(foo='bar'))
         assert hasattr(searcher[0], '_id')
-        assert hasattr(searcher[0], '_score')
-        assert hasattr(searcher[0], '_source')
-        assert hasattr(searcher[0], '_type')
-        assert hasattr(searcher[0], '_explanation')
-        assert hasattr(searcher[0], '_highlight')
+        assert hasattr(searcher[0].es_meta, 'id')
+        assert hasattr(searcher[0].es_meta, 'score')
+        assert hasattr(searcher[0].es_meta, 'source')
+        assert hasattr(searcher[0].es_meta, 'type')
+        assert hasattr(searcher[0].es_meta, 'explanation')
+        assert hasattr(searcher[0].es_meta, 'highlight')
 
     def test_values_list_form_has_metadata(self):
         """Test default results form has metadata."""
         searcher = list(self.get_s().query(foo='bar').values_list('id'))
         assert hasattr(searcher[0], '_id')
-        assert hasattr(searcher[0], '_score')
-        assert hasattr(searcher[0], '_source')
-        assert hasattr(searcher[0], '_type')
-        assert hasattr(searcher[0], '_explanation')
-        assert hasattr(searcher[0], '_highlight')
+        assert hasattr(searcher[0].es_meta, 'id')
+        assert hasattr(searcher[0].es_meta, 'score')
+        assert hasattr(searcher[0].es_meta, 'source')
+        assert hasattr(searcher[0].es_meta, 'type')
+        assert hasattr(searcher[0].es_meta, 'explanation')
+        assert hasattr(searcher[0].es_meta, 'highlight')
 
     def test_values_dict_form_has_metadata(self):
         """Test default results form has metadata."""
         searcher = list(self.get_s().query(foo='bar').values_dict())
         assert hasattr(searcher[0], '_id')
-        assert hasattr(searcher[0], '_score')
-        assert hasattr(searcher[0], '_source')
-        assert hasattr(searcher[0], '_type')
-        assert hasattr(searcher[0], '_explanation')
-        assert hasattr(searcher[0], '_highlight')
+        assert hasattr(searcher[0].es_meta, 'id')
+        assert hasattr(searcher[0].es_meta, 'score')
+        assert hasattr(searcher[0].es_meta, 'source')
+        assert hasattr(searcher[0].es_meta, 'type')
+        assert hasattr(searcher[0].es_meta, 'explanation')
+        assert hasattr(searcher[0].es_meta, 'highlight')
 
     def test_values_dict_no_args(self):
         """Calling values_dict() with no args fetches all fields."""


### PR DESCRIPTION
Django templates don't allow you to expose variables that start with an
_. So having:

```
obj._highlight
```

sucked.

We've got a fair number of these metadata items and I'm concerned with
each new one we add, we increase the likelihood that there's a naming
conflict with actual data.

So this moves all those items into an es_meta object which you can
access like this:

```
obj.es_meta.highlight
```

The one exception is _id--you can now access the id Elasticsearch gives
the document with both:

```
obj._id
```

and:

```
obj.es_meta.id
```

Fixes #205
