### PR TITLE
Fix bulk indexing problems with Elasticsearch 1.0

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from datetime import datetime
 from operator import itemgetter
+
 import six
 from six import string_types
 
@@ -9,6 +10,10 @@ from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk_index
 
 from elasticutils._version import __version__  # noqa
+from elasticutils import monkeypatch
+
+
+monkeypatch.monkeypatch_es()
 
 
 log = logging.getLogger('elasticutils')

--- a/elasticutils/monkeypatch.py
+++ b/elasticutils/monkeypatch.py
@@ -1,0 +1,35 @@
+from functools import wraps
+
+from elasticsearch import Elasticsearch, VERSION
+
+
+_monkeypatched_es = False
+
+
+def monkeypatch_es():
+    """Monkey patch for elasticsearch-py 0.4.5 to make it work with ES 1.0
+
+    1. tweaks elasticsearch.client.bulk to normalize return status codes
+
+    """
+    if _monkeypatched_es:
+        return
+
+    if VERSION == (0, 4, 5):
+        def normalize_bulk_return(fun):
+            """Set's "ok" based on "status" if "status" exists"""
+            @wraps(fun)
+            def _fixed_bulk(self, *args, **kwargs):
+                def fix_item(item):
+                    if 'status' in item['index']:
+                        item['index']['ok'] = (
+                            200 <= item['index']['status'] < 300)
+                    return item
+
+                ret = fun(self, *args, **kwargs)
+                if 'items' in ret:
+                    ret['items'] = [fix_item(item) for item in ret['items']]
+                return ret
+            return _fixed_bulk
+
+        Elasticsearch.bulk = normalize_bulk_return(Elasticsearch.bulk)


### PR DESCRIPTION
In order for ElasticUtils to work for both Elasticsearch 0.90 and
Elasticsearch 1.0 using elasticsearch-py 0.4.5, we need to do some
monkey-patching of elasticsearch-py.

In this case, calling Elasticsearch.client.bulk() returns an 'ok' field
with ES 0.90 and a 'status' field with ES 1.0. This patch sets the 'ok'
field based on the 'status' field so that the bulk indexing
infrastructure in elasticsearch-py 0.4.5 is testing the right thing and
not raising BulkIndexingErrors.

Fixes #241

r?
