### PR TITLE
terms_stats facet type support

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -28,6 +28,7 @@ FACET_TYPES = [
     'range',
     'statistical',
     'terms',
+    'terms_stats',
 ]
 
 #: Maps ElasticUtils field actions to their Elasticsearch query names.

--- a/elasticutils/estestcase.py
+++ b/elasticutils/estestcase.py
@@ -113,6 +113,19 @@ class ESTestCase(TestCase):
         cls.get_es().indices.create(index=cls.index_name, body=body)
 
     @classmethod
+    def put_mapping(cls, mapping):
+        """Creates an index with specified settings
+
+        Uses ``cls.index_name`` as the index to create.
+
+        :arg settings: Any additional settings to use to create the
+            index.
+
+        """
+        cls.get_es().indices.put_mapping(
+        index=cls.index_name, doc_type=cls.mapping_type_name, body=mapping)
+
+    @classmethod
     def index_data(cls, documents, id_field='id'):
         """Indexes specified data
 


### PR DESCRIPTION
adds terms stats support.

I think it's failing because travis pulling down the wrong version of ES and my code is still based on .9. I can update it if need be. Tests are passing locally for me though.

Much <3 if this can be into .10.
