### PR TITLE
Fix travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,23 @@ language: python
 
 notifications:
     email: false
+    irc:
+        channels:
+            - "irc.mozilla.org#elasticutils"
+        on_success: always
+        on_failure: always
 
 python:
     - "2.6"
     - "2.7"
     - "3.3"
+    - "3.4"
 
 env:
     - ESVER=0.90.13
     - ESVER=1.0.3
+    - ESVER=1.1.2
+    - ESVER=1.2.4
 
 install:
     - scripts/travis/install.sh

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,3 +1,3 @@
-django
+django<1.7
 celery>=2.5.5
 django-celery


### PR DESCRIPTION
- Add more Elasticsearch versions to the Travis matrix.
- ElasticUtils may not work with Django 1.7. At a minimum, we know that
  tests don't pass. For now, restricting the Django version to <1.7.

Testing travis fixes.
