### PR TITLE
Update requirements to elasticsearch >= 1.0

### DIFF
--- a/elasticutils/monkeypatch.py
+++ b/elasticutils/monkeypatch.py
@@ -1,35 +1,37 @@
 from functools import wraps
 
-from elasticsearch import Elasticsearch, VERSION
+from elasticsearch import Elasticsearch
 
 
 _monkeypatched_es = False
 
 
 def monkeypatch_es():
-    """Monkey patch for elasticsearch-py 0.4.5 to make it work with ES 1.0
+    """Monkey patch for elasticsearch-py 1.0+ to make it work with ES 0.90
 
     1. tweaks elasticsearch.client.bulk to normalize return status codes
+
+    .. Note::
+
+       We can nix this whe we drop support for ES 0.90.
 
     """
     if _monkeypatched_es:
         return
 
-    if VERSION == (0, 4, 5):
-        def normalize_bulk_return(fun):
-            """Set's "ok" based on "status" if "status" exists"""
-            @wraps(fun)
-            def _fixed_bulk(self, *args, **kwargs):
-                def fix_item(item):
-                    if 'status' in item['index']:
-                        item['index']['ok'] = (
-                            200 <= item['index']['status'] < 300)
-                    return item
+    def normalize_bulk_return(fun):
+        """Set's "ok" based on "status" if "status" exists"""
+        @wraps(fun)
+        def _fixed_bulk(self, *args, **kwargs):
+            def fix_item(item):
+                if 'ok' in item['index']:
+                    item['index']['status'] = 201
+                return item
 
-                ret = fun(self, *args, **kwargs)
-                if 'items' in ret:
-                    ret['items'] = [fix_item(item) for item in ret['items']]
-                return ret
-            return _fixed_bulk
+            ret = fun(self, *args, **kwargs)
+            if 'items' in ret:
+                ret['items'] = [fix_item(item) for item in ret['items']]
+            return ret
+        return _fixed_bulk
 
-        Elasticsearch.bulk = normalize_bulk_return(Elasticsearch.bulk)
+    Elasticsearch.bulk = normalize_bulk_return(Elasticsearch.bulk)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'elasticsearch >= 0.4.3, < 1.0',
+        'elasticsearch>=1.0',
         'six'
     ],
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,28 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26_dj14, py27_dj14, py26_dj15, py27_dj15, py26_dj16, py27_dj16, py33_dj15, py33_dj16, py34_dj15, py34_dj16
+envlist = py27_es10, py27_es111, py27_es120, py26_dj14, py27_dj14, py26_dj15, py27_dj15, py26_dj16, py27_dj16, py33_dj15, py33_dj16, py34_dj15, py34_dj16
+
+[testenv:py27_es10]
+basepython = python2.7
+commands = pip install elasticsearch==1.0.0
+           pip install django<1.6.99
+           pip install -r requirements/dev.txt
+           {envpython} run_tests.py
+
+[testenv:py27_es111]
+basepython = python2.7
+commands = pip install elasticsearch==1.1.1
+           pip install django<1.6.99
+           pip install -r requirements/dev.txt
+           {envpython} run_tests.py
+
+[testenv:py27_es120]
+basepython = python2.7
+commands = pip install elasticsearch==1.2.0
+           pip install django<1.6.99
+           pip install -r requirements/dev.txt
+           {envpython} run_tests.py
 
 [testenv:py26_dj14]
 basepython = python2.6


### PR DESCRIPTION
This inverts the monkeypatch so that we can continue to work with
ElasticUtils 0.90, but use elasticsearch-py >= 1.0. That makes things a
lot easier going forward.

Can someone look through this and make sure it's ok?
