### PR TITLE
Fix infinite recursion when unpickling a mapping type instance

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -2070,6 +2070,11 @@ class MappingType(object):
             # subclasses.
             return self.get_object()
 
+        if name == '_results_dict':
+            # Prevent infinite recursion when unpickling a
+            # mapping type instance.
+            raise AttributeError(name)
+
         # If that doesn't exist, then check the results_dict.
         if name in self._results_dict:
             return self._results_dict[name]


### PR DESCRIPTION
I noticed that unpickling mapping type instances led to infinite recursion. This happened when I tried to cache search results in Django (using `django.core.cache`).

Reproducing the problem:

```
# mt is a mapping type instance
import pickle
pickled = pickle.dumps(mt, 2)
unpickled = pickle.loads(pickled)
```

This should lead to a RuntimeError because of the infinite recursion. The fix prevents this from happening.
