### PR TITLE
Add term_stats facet type.

### DIFF
--- a/elasticutils/__init__.py
+++ b/elasticutils/__init__.py
@@ -34,6 +34,7 @@ FACET_TYPES = [
     'range',
     'statistical',
     'terms',
+    'terms_stats',
 ]
 
 #: Maps ElasticUtils field actions to their Elasticsearch query names.


### PR DESCRIPTION
Yes, this is deprecated. Yes, kitsune should switch to something else.

But I just want this facet to work. I tested this by changing it locally and then almost forgetting that I needed to make this pull request while I used it.

It would be super awesome to publish a 0.10.3 with this change.
